### PR TITLE
Added check to preserve ratio of the crop on scaling. This is configurable and uses ratio option set while invoking darkroom

### DIFF
--- a/lib/js/plugins/darkroom.crop.js
+++ b/lib/js/plugins/darkroom.crop.js
@@ -192,6 +192,7 @@
         return;
       }
 
+      var preventScaling = false;
       var currentObject = event.target;
       if (currentObject !== this.cropZone)
         return;
@@ -205,7 +206,13 @@
       var maxX = currentObject.getLeft() + currentObject.getWidth();
       var maxY = currentObject.getTop() + currentObject.getHeight();
 
-      if (minX < 0 || maxX > canvas.getWidth()) {
+      if (null !== this.options.ratio) {
+		if (minX < 0 || maxX > canvas.getWidth() || minY < 0 || maxY > canvas.getHeight()) {
+			preventScaling = true;
+		}
+	  }
+
+      if (minX < 0 || maxX > canvas.getWidth() || preventScaling) {
         var lastScaleX = this.lastScaleX || 1;
         currentObject.setScaleX(lastScaleX);
       }
@@ -213,7 +220,7 @@
         currentObject.setLeft(0);
       }
 
-      if (minY < 0 || maxY > canvas.getHeight()) {
+      if (minY < 0 || maxY > canvas.getHeight() || preventScaling) {
         var lastScaleY = this.lastScaleY || 1;
         currentObject.setScaleY(lastScaleY);
       }


### PR DESCRIPTION
@MattKetmo

Thank you for coming up with this plugin. It was very useful. I found a small bug in the crop plugin, which is while an crop is scaled and ratio is set, the crop does not respect the ration set once it hits either the boundaries of width or height. This is a fix for that. 
