### PR TITLE
Track image source, in case it is larger then Canvas view

### DIFF
--- a/lib/js/darkroom.js
+++ b/lib/js/darkroom.js
@@ -188,6 +188,9 @@
       init: function() {}
     },
 
+    // Store source image in case it is larger then Darkrooms canvas
+    source: null,
+
     // Add ability to attach event listener on the core object.
     // It uses the canvas element to process events.
     addEventListener: function(eventName, callback) {
@@ -270,12 +273,16 @@
         backgroundColor: '#ccc',
       });
 
+      this.addFabricImage();
+      return this;
+    },
+
+    addFabricImage: function(){
       this.canvas.setWidth(this.image.getWidth());
       this.canvas.setHeight(this.image.getHeight());
       this.canvas.add(this.image);
       this.canvas.centerObject(this.image);
       this.image.setCoords();
-
       return this;
     },
 
@@ -310,6 +317,7 @@
       width *= scale;
       height *= scale;
 
+      this.source = scale === 1 ? null : imgElement;
       this.image = new fabric.Image(imgElement, {
         // options to make the image static
         selectable: false,
@@ -367,8 +375,31 @@
 
     snapshotImage: function() {
       return this.image.toDataURL();
+    },
+
+    toDataURL: function(options) {
+      if (this.source != null) {
+        return Darkroom.imgToCanvas(this.source).toDataURL(options);
+      }
+      return this.image.toDataURL(options);
     }
 
+  };
+
+  Darkroom.imgToCanvas = function(img, x, y, w, h) {
+    if (x == null) {
+      x = 0;
+      y = 0;
+      w = img.width;
+      h = img.height;
+    }
+    var canvas = document.createElement('canvas');
+    canvas.width = w;
+    canvas.height = h;
+    canvas.getContext('2d').drawImage(
+      img, x, y, w, h, 0, 0, w, h
+    );
+    return canvas;
   };
 
 })(window, window.document, fabric);

--- a/lib/js/plugins/darkroom.crop.js
+++ b/lib/js/plugins/darkroom.crop.js
@@ -416,40 +416,37 @@
           return;
         }
 
-        var imgInstance = new fabric.Image(this, {
-          // options to make the image static
-          selectable: false,
-          evented: false,
-          lockMovementX: true,
-          lockMovementY: true,
-          lockRotation: true,
-          lockScalingX: true,
-          lockScalingY: true,
-          lockUniScaling: true,
-          hasControls: false,
-          hasBorders: false
-        });
-
-        var width = this.width;
-        var height = this.height;
-
-        // Update canvas size
-        canvas.setWidth(width);
-        canvas.setHeight(height);
-
-        // Add image
-        _this.darkroom.image.remove();
-        _this.darkroom.image = imgInstance;
-        canvas.add(imgInstance);
-
-        darkroom.dispatchEvent('image:change');
+        darkroom.image.remove();
+        darkroom
+          .createFabricImage(this)
+          .addFabricImage()
+          .dispatchEvent('image:change');
       };
 
+      var cropW = this.cropZone.getWidth(),
+          cropH = this.cropZone.getHeight(),
+          cropX = this.cropZone.getLeft(),
+          cropY = this.cropZone.getTop();
+
+      var source = darkroom.source;
+      if (source != null && canvas.getWidth() < source.width) {
+        var transform = source.width / canvas.getWidth();
+        var canvas$ = Darkroom.imgToCanvas(
+          source,
+          cropX * transform,
+          cropY * transform,
+          cropW * transform,
+          cropH * transform
+        );
+        image.src = canvas$.toDataURL();
+        return;
+      }
+  
       image.src = canvas.toDataURL({
-        left: this.cropZone.getLeft(),
-        top: this.cropZone.getTop(),
-        width: this.cropZone.getWidth(),
-        height: this.cropZone.getHeight()
+        left: cropX,
+        top: cropY,
+        width: cropW,
+        height: cropH
       });
     },
 

--- a/lib/js/plugins/darkroom.history.js
+++ b/lib/js/plugins/darkroom.history.js
@@ -18,9 +18,9 @@
         return;
       }
 
-      this.forwardHistoryStack.push(this.currentImage);
-      this.currentImage = this.backHistoryStack.pop();
-      this._applyImage(this.currentImage);
+      this.forwardHistoryStack.push(this.state);
+      this.state = this.backHistoryStack.pop();
+      this._applyState(this.state);
       this._updateButtons();
     },
 
@@ -29,9 +29,9 @@
         return;
       }
 
-      this.backHistoryStack.push(this.currentImage);
-      this.currentImage = this.forwardHistoryStack.pop();
-      this._applyImage(this.currentImage);
+      this.backHistoryStack.push(this.state);
+      this.state = this.forwardHistoryStack.pop();
+      this._applyState(this.state);
       this._updateButtons();
     },
 
@@ -60,22 +60,25 @@
     },
 
     _snapshotImage: function() {
-      var _this = this;
       var image = new Image();
       image.src = this.darkroom.snapshotImage();
 
-      this.currentImage = image;
+      this.state = {
+        image: image,
+        source: this.darkroom.source
+      };
     },
 
     _onImageChange: function() {
-      this.backHistoryStack.push(this.currentImage);
+      this.backHistoryStack.push(this.state);
       this._snapshotImage();
       this.forwardHistoryStack.length = 0;
       this._updateButtons();
     },
 
     // Apply image to the canvas
-    _applyImage: function(image) {
+    _applyState: function(state) {
+      var image = state.image;
       var canvas = this.darkroom.canvas;
 
       var imgInstance = new fabric.Image(image, {
@@ -100,6 +103,9 @@
       this.darkroom.image.remove();
       this.darkroom.image = imgInstance;
       canvas.add(imgInstance);
+      
+      // Update source
+      this.darkroom.source = state.source;
     }
   });
 })(window, document, Darkroom, fabric);


### PR DESCRIPTION
Hi Matthieu, 

this pr is about [#13](https://github.com/MattKetmo/darkroomjs/issues/13). It performs crop using original image when the canvas was down scaled to `maxWidth/maxHeight`. So now it is possible to scale canvas to fit the container, but origin area size remains after cropping.

Or do you have other ideas to the subject?
