### PR TITLE
Use fabrics getPointer in mouse events

### DIFF
--- a/lib/js/plugins/darkroom.crop.js
+++ b/lib/js/plugins/darkroom.crop.js
@@ -210,8 +210,9 @@
         return;
 
       var canvas = this.darkroom.canvas;
-      var x = event.e.pageX - canvas._offset.left;
-      var y = event.e.pageY - canvas._offset.top;
+      var pointer = canvas.getPointer(event.e);
+      var x = pointer.x;
+      var y = pointer.y;
 
       var minX = currentObject.getLeft();
       var minY = currentObject.getTop();
@@ -260,8 +261,12 @@
       }
 
       var canvas = this.darkroom.canvas;
-      var x = event.e.pageX - canvas._offset.left;
-      var y = event.e.pageY - canvas._offset.top;
+
+      // recalculate offset, in case canvas was manipulated since last `calcOffset`
+      canvas.calcOffset();
+      var pointer = canvas.getPointer(event.e);
+      var x = pointer.x;
+      var y = pointer.y;
       var point = new fabric.Point(x, y);
 
       // Check if user want to scale or drag the crop zone.
@@ -291,8 +296,9 @@
       }
 
       var canvas = this.darkroom.canvas;
-      var x = event.e.pageX - canvas._offset.left;
-      var y = event.e.pageY - canvas._offset.top;
+      var pointer = canvas.getPointer(event.e);
+      var x = pointer.x;
+      var y = pointer.y;
 
       this._renderCropZone(this.startX, this.startY, x, y);
     },
@@ -301,8 +307,9 @@
       var canvas = this.darkroom.canvas;
       var zone = this.cropZone;
 
-      var x = event.e.pageX - canvas._offset.left;
-      var y = event.e.pageY - canvas._offset.top;
+      var pointer = canvas.getPointer(event.e);
+      var x = pointer.x;
+      var y = pointer.y;
 
       if (!zone.left || !zone.top) {
         zone.setTop(y);


### PR DESCRIPTION
Hi Matthieu,

there was an issue with `x/y` calculation in mouse event handlers of the crop plugin. `pageX/pageY` was used with  fabrics `_offset.left/_offset.top`. It becomes sometimes invalid, e.g. if any canvas ancestor is fixed positioned. Better to use built in tool for those calculations - `canvas.getPointer`.  Now cropping area has proper position in fixed containers, like modal dialogs.
