### PR TITLE
selfDestroy maintains ID on image

### DIFF
--- a/lib/js/darkroom.js
+++ b/lib/js/darkroom.js
@@ -354,6 +354,8 @@
       var container = this.container;
 
       var image = new Image();
+      image.id = this.image._originalElement.id;
+      
       image.onload = function() {
         container.parentNode.replaceChild(image, container);
       }

--- a/lib/js/plugins/darkroom.crop.js
+++ b/lib/js/plugins/darkroom.crop.js
@@ -445,8 +445,10 @@
         canvas.setHeight(height);
 
         // Add image
+        var originalElement = _this.darkroom.image._originalElement;
         _this.darkroom.image.remove();
         _this.darkroom.image = imgInstance;
+        imgInstance._originalElement = originalElement;
         canvas.add(imgInstance);
 
         darkroom.dispatchEvent('image:change');


### PR DESCRIPTION
When selfdestroy is called, the image that is passed back to the ui should have the same id as the original image that was there so that it can be referred to again.