### PR TITLE
Add Callbacks

### DIFF
--- a/lib/js/darkroom.js
+++ b/lib/js/darkroom.js
@@ -186,7 +186,10 @@
       plugins: {},
 
       // after initialisation callback
-      init: function() {}
+      init: function() {},
+
+      // after DOM initialisation callback
+      initDOM: function() {}
     },
 
     // Add ability to attach event listener on the core object.
@@ -276,6 +279,9 @@
       this.canvas.add(this.image);
       this.canvas.centerObject(this.image);
       this.image.setCoords();
+
+      // Execute a custom callback after DOM initialisation
+      this.options.initDOM.bind(this).call();
 
       return this;
     },

--- a/lib/js/plugins/darkroom.crop.js
+++ b/lib/js/plugins/darkroom.crop.js
@@ -132,7 +132,19 @@
       // ensure crop ratio
       ratio: null,
       // quick crop feature (set a key code to enable it)
-      quickCropKey: false
+      quickCropKey: false,
+      cropCallback : function()
+      {
+        this.toggleCrop();
+      },
+      okCallback : function()
+      {
+        this.cropCurrentZone();
+      },
+      cancelCallback : function()
+      {
+        this.releaseFocus();
+      }
     },
 
     initialize: function InitDarkroomCropPlugin() {
@@ -153,9 +165,9 @@
       });
 
       // Buttons click
-      this.cropButton.addEventListener('click', this.toggleCrop.bind(this));
-      this.okButton.addEventListener('click', this.cropCurrentZone.bind(this));
-      this.cancelButton.addEventListener('click', this.releaseFocus.bind(this));
+      this.cropButton.addEventListener('click', this.options.cropCallback.bind(this));
+      this.okButton.addEventListener('click', this.options.okCallback.bind(this));
+      this.cancelButton.addEventListener('click', this.options.cancelCallback.bind(this));
 
       // Canvas events
       this.darkroom.canvas.on('mouse:down', this.onMouseDown.bind(this));


### PR DESCRIPTION
I had the need to intercept various functionality without wanting to modify the core. So I have added a `initDOM();` *callback* function (mimicking the `init();` *callback*) to allow for customising the toolbar HTML.

I also needed to add additional logic to the crop buttons and so created *callbacks* for these buttons like the **Save** plugin.