### PR TITLE
Improve keyboard accessibility

### DIFF
--- a/lib/css/_buttons.scss
+++ b/lib/css/_buttons.scss
@@ -5,7 +5,7 @@
   font-weight: 300;
   border: none;
   font-size: 28px;
-  outline: none;
+  /* outline: none; Please do not reinstate this, it hinders keyboard accessibility of the buttons */
   padding: 0;
   height: 40px;
   width: 40px;

--- a/lib/css/_global.scss
+++ b/lib/css/_global.scss
@@ -1,0 +1,5 @@
+.visuallyhidden {
+  /* Style for accessible text */
+  position: absolute;
+  left: -999px;
+}

--- a/lib/css/darkroom.scss
+++ b/lib/css/darkroom.scss
@@ -1,3 +1,4 @@
+@import 'global';
 @import 'layout';
 @import 'buttons';
 @import 'toolbar';

--- a/lib/js/darkroom.js
+++ b/lib/js/darkroom.js
@@ -55,7 +55,7 @@
   Plugin.prototype = {
     defaults: {},
     initialize: function() { }
-  }
+  };
 
   // Inspired by Backbone.js extend capability.
   Plugin.extend = function(protoProps) {
@@ -79,7 +79,7 @@
     child.__super__ = parent.prototype;
 
     return child;
-  }
+  };
 
   // Attach the plugin class into the main namespace.
   Darkroom.Plugin = Plugin;
@@ -112,6 +112,7 @@
       image: 'help',
       type: 'default',
       group: 'default',
+      label: 'Help',
       hide: false,
       disabled: false
     };
@@ -119,8 +120,11 @@
     options = extend(options, defaults);
 
     var button = document.createElement('button');
+    var html = '<i class="darkroom-icon-' + options.image + '"></i>';
+    html += '<span class="visuallyhidden">' + options.label + '</span>';
     button.className = 'darkroom-button darkroom-button-' + options.type;
-    button.innerHTML = '<i class="darkroom-icon-' + options.image + '"></i>';
+    button.innerHTML = html;
+    button.title = options.label;  // hover text for mouse users
     this.element.appendChild(button);
 
     var button = new Button(button);
@@ -128,7 +132,7 @@
     button.disable(options.disabled);
 
     return button;
-  }
+  };
 
   // Button object.
   function Button(element) {
@@ -235,7 +239,7 @@
 
         // Execute a custom callback after initialization
         _this.options.init.bind(_this).call();
-      }
+      };
 
       /*image.crossOrigin = 'anonymous';*/
       image.src = element.src;
@@ -356,7 +360,7 @@
       var image = new Image();
       image.onload = function() {
         container.parentNode.replaceChild(image, container);
-      }
+      };
 
       image.src = this.snapshotImage();
 

--- a/lib/js/plugins/darkroom.crop.js
+++ b/lib/js/plugins/darkroom.crop.js
@@ -5,7 +5,6 @@
     _render: function(ctx) {
       this.callSuper('_render', ctx);
 
-      var canvas = ctx.canvas;
       var dashWidth = 7;
 
       // Set original scale
@@ -139,16 +138,19 @@
       var buttonGroup = this.darkroom.toolbar.createButtonGroup();
 
       this.cropButton = buttonGroup.createButton({
-        image: 'crop'
+        image: 'crop',
+        label: 'Crop'
       });
       this.okButton = buttonGroup.createButton({
         image: 'accept',
         type: 'success',
+        label: 'Accept crop',
         hide: true
       });
       this.cancelButton = buttonGroup.createButton({
         image: 'cancel',
         type: 'danger',
+        label: 'Cancel crop',
         hide: true
       });
 
@@ -479,7 +481,7 @@
         cornerSize: 8,
         transparentCorners: false,
         lockRotation: true,
-        hasRotatingPoint: false,
+        hasRotatingPoint: false
       });
 
       if (null !== this.options.ratio) {
@@ -531,7 +533,7 @@
       // Replace current point into the canvas
       leftX = Math.max(0, leftX);
       rightX = Math.min(canvas.getWidth(), rightX);
-      topY = Math.max(0, topY)
+      topY = Math.max(0, topY);
       bottomY = Math.min(canvas.getHeight(), bottomY);
 
       // Recalibrate coordinates according to given options
@@ -552,7 +554,7 @@
       if (leftX < 0) {
         // Translate to the left
         rightX += Math.abs(leftX);
-        leftX = 0
+        leftX = 0;
       }
       if (rightX > canvas.getWidth()) {
         // Translate to the right
@@ -562,7 +564,7 @@
       if (topY < 0) {
         // Translate to the bottom
         bottomY += Math.abs(topY);
-        topY = 0
+        topY = 0;
       }
       if (bottomY > canvas.getHeight()) {
         // Translate to the right

--- a/lib/js/plugins/darkroom.history.js
+++ b/lib/js/plugins/darkroom.history.js
@@ -23,7 +23,7 @@
       this._applyImage(this.currentImage);
       this._updateButtons();
 
-      // Dispatch an event, so listeners will know the 
+      // Dispatch an event, so listeners will know the
       // currently viewed image has been changed.
       this.darkroom.dispatchEvent('history:navigate');
     },
@@ -38,7 +38,7 @@
       this._applyImage(this.currentImage);
       this._updateButtons();
 
-      // Dispatch an event, so listeners will know the 
+      // Dispatch an event, so listeners will know the
       // currently viewed image has been changed.
       this.darkroom.dispatchEvent('history:navigate');
     },
@@ -48,11 +48,13 @@
 
       this.backButton = buttonGroup.createButton({
         image: 'back',
+        label: 'History back',
         disabled: true
       });
 
       this.forwardButton = buttonGroup.createButton({
         image: 'forward',
+        label: 'History forward',
         disabled: true
       });
 
@@ -63,8 +65,8 @@
     },
 
     _updateButtons: function() {
-      this.backButton.disable((this.backHistoryStack.length === 0))
-      this.forwardButton.disable((this.forwardHistoryStack.length === 0))
+      this.backButton.disable((this.backHistoryStack.length === 0));
+      this.forwardButton.disable((this.forwardHistoryStack.length === 0));
     },
 
     _snapshotImage: function() {

--- a/lib/js/plugins/darkroom.rotate.js
+++ b/lib/js/plugins/darkroom.rotate.js
@@ -6,11 +6,13 @@
       var buttonGroup = this.darkroom.toolbar.createButtonGroup();
 
       this.leftButton = buttonGroup.createButton({
-        image: 'rotate-left'
+        image: 'rotate-left',
+        label: 'Rotate left'
       });
 
       this.rightButton = buttonGroup.createButton({
-        image: 'rotate-right'
+        image: 'rotate-right',
+        label: 'Rotate right'
       });
 
       this.leftButton.addEventListener('click', this.rotateLeft.bind(this));

--- a/lib/js/plugins/darkroom.save.js
+++ b/lib/js/plugins/darkroom.save.js
@@ -12,10 +12,11 @@
       var buttonGroup = this.darkroom.toolbar.createButtonGroup();
 
       this.destroyButton = buttonGroup.createButton({
-        image: 'save'
+        image: 'save',
+        label: 'Save'
       });
 
       this.destroyButton.addEventListener('click', this.options.callback.bind(this));
-    },
+    }
   });
 })(window, document, Darkroom);


### PR DESCRIPTION
Two main changes in this PR:
1. Remove "outline: none" from button to improve keyboard accessibility:
   - Most of the functions of Darkroom are keyboard drivable (e.g. Save, Rotate, History). Granted - crop would be hard to get working from keyboard alone.
   - Removing focus indicator from any form controls or links impedes keyboard accessibility.
   - More information and links to further reading here: http://www.outlinenone.com/
2. Add "label text" to the buttons:
   - This is primarily to aid assistive technology (AT) - think "screen reader". You may wonder why the visually impaired would want to edit images - there are all sorts of AT and all sorts of screen reader users, not just "blind people".
   - A secondary benefit is that it allows the labels to be displayed, if necessary or desired. Improving accessibility almost always benefits all users, not just AT users.

I did some random cleanup if anything jumped out at me (couple of missing semicolons).
