### PR TITLE
add umd entry point for npm and others

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -10,6 +10,8 @@ var sourcemaps = require('gulp-sourcemaps')
 var svgmin = require('gulp-svgmin')
 var svgstore = require('gulp-svgstore')
 var uglify = require('gulp-uglify')
+var webpack = require('webpack')
+var webpackcfg = require('./webpack.config')
 
 
 //
@@ -37,7 +39,7 @@ gulp.task('clean', function(cb) {
 // Build
 //
 gulp.task('build', ['clean'], function() {
-  gulp.start('scripts', 'styles');
+  gulp.start('scripts', 'umd', 'styles');
 });
 
 //
@@ -93,6 +95,17 @@ gulp.task('scripts', function () {
     .pipe(isDebug ? sourcemaps.write() : gutil.noop())
     .pipe(gulp.dest(distDir))
 })
+
+//
+// Umd
+//
+gulp.task('umd', function (done) {
+  webpack(webpackcfg, function(err, stats) {
+    if (err) throw new gutil.PluginError('webpack', err);
+    gutil.log('[webpack]', stats.toString());
+    done();
+  });
+});
 
 //
 // Stylesheet

--- a/lib/js/commonjs/index.js
+++ b/lib/js/commonjs/index.js
@@ -1,0 +1,12 @@
+require('../core/bootstrap');
+require('../core/darkroom');
+require('../core/plugin');
+require('../core/transformation');
+require('../core/ui');
+require('../core/utils');
+require('../plugins/darkroom.history');
+require('../plugins/darkroom.rotate');
+require('../plugins/darkroom.crop');
+require('../plugins/darkroom.save');
+
+module.exports = window.Darkroom;

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "darkroom",
   "description": "Extensible image editing tool via HTML canvas",
   "version": "2.0.0",
+  "main": "build/darkroom.umd.js",
   "license": "MIT",
   "homepage": "https://mattketmo.github.io/darkroomjs",
   "repository": {
@@ -22,7 +23,8 @@
     "gulp-svgstore": "^5.0.0",
     "gulp-uglify": "^1.4.1",
     "gulp-util": "^3.0.0",
-    "rimraf": "^2.2.8"
+    "rimraf": "^2.2.8",
+    "webpack": "^1.12.2"
   },
   "scripts": {
     "start": "node_modules/.bin/gulp server build --prod",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,0 +1,17 @@
+var webpack = require('webpack');
+
+module.exports = {
+  entry: './lib/js/commonjs/index.js',
+  output: {
+    path: __dirname + '/build',
+    filename: 'darkroom.umd.js',
+    library: 'Darkroom',
+    libraryTarget: 'umd'
+  },
+  resolve: {
+    extensions: ['', '.js']
+  },
+  plugins: [
+    new webpack.optimize.OccurenceOrderPlugin()
+  ]
+};


### PR DESCRIPTION
Relate to #62. npm user need a commonjs entry point, and other commonjs, amd users also can use umd module. But it's not ideal now, because original source use global window to communicate between files.